### PR TITLE
allow setting sslmode from config file

### DIFF
--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -11,4 +11,5 @@ func setupDefaults() {
 	v.SetDefault("postgres.dbname", "friendlystripe")
 	v.SetDefault("postgres.user", "postgres")
 	v.SetDefault("postgres.password", "")
+	v.SetDefault("postgres.sslmode", "disable")
 }

--- a/internal/db/postgres/store.go
+++ b/internal/db/postgres/store.go
@@ -16,8 +16,8 @@ import (
 func BuildConnectionDSN(dbname string) string {
 	password := viper.GetString("postgres.password")
 
-	dsn := fmt.Sprintf("host=%s port=%d dbname=%s user=%s sslmode=disable",
-		viper.GetString("postgres.host"), viper.GetInt("postgres.port"), dbname, viper.GetString("postgres.user"))
+	dsn := fmt.Sprintf("host=%s port=%d dbname=%s user=%s sslmode=%s",
+		viper.GetString("postgres.host"), viper.GetInt("postgres.port"), dbname, viper.GetString("postgres.user"), viper.GetString("postgres.sslmode"))
 
 	if password != "" {
 		dsn += " password=" + password


### PR DESCRIPTION
Hey, this little change made it possible for me to connect to an AWS RDS by setting `sslmode=require` in the config file. 
Thanks!