### PR TITLE
Fix/augment version output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVar(&config.CfgFile, "config", "", "config file (default is $HOME/.friendly-stripe-sync.yaml)")
 
-	rootCmd.Version = buildinfo.Version() + " " + buildinfo.Target() + " (" + buildinfo.CommitDate() + ") " + buildinfo.Commit()
+	rootCmd.Version = buildinfo.FullVersion()
 
 	rootCmd.PersistentFlags().BoolP("development", "d", false, "Development mode (prints prettier log messages)")
 	rootCmd.PersistentFlags().BoolP("debug", "D", false, "Debug mode (prints debug messages and call traces)")

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - 386
       - arm64
     ldflags:
-      - -s -w -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.version={{.Version}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.commit={{.Commit}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.date={{.CommitDate}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.target={{.Env.GOOS}}
+      - -s -w -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.version={{.Version}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.commit={{.Commit}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.commitDate={{.CommitDate}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.target={{.Env.GOOS}}
     env:
       - CGO_ENABLED=0
 archives:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -13,7 +13,7 @@ builds:
       - 386
       - arm64
     ldflags:
-      - -s -w -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.version={{.Version}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.commit={{.Commit}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.commitDate={{.CommitDate}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.target={{.Env.GOOS}}
+      - -s -w -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.version={{.Version}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.commit={{.Commit}} -X github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo.commitDate={{.CommitDate}}
     env:
       - CGO_ENABLED=0
 archives:

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,11 +1,15 @@
 package buildinfo
 
+import (
+	"fmt"
+	"runtime"
+)
+
 // Fields injected by goreleaser
 var (
 	version    = "<unknown>"
 	commitDate = "date unknown"
 	commit     = ""
-	target     = ""
 )
 
 func Version() string {
@@ -21,5 +25,10 @@ func Commit() string {
 }
 
 func Target() string {
-	return target
+	return runtime.GOOS
+}
+
+func FullVersion() string {
+	return fmt.Sprintf("%s %s/%s %s (%s) %s",
+		version, runtime.GOOS, runtime.GOARCH, runtime.Version(), commitDate, commit)
 }


### PR DESCRIPTION
This fixes and augments the output of the `--version` CLI flag to properly include the commit date, and the Go version and arch information.

Before:
```shell
friendly-stripe-sync version 0.1.3-SNAPSHOT-236b3de linux (date unknown) 236b3de071511469c2a7f201180fa5b927a46fe6
```

After:
```shell
friendly-stripe-sync version 0.1.3-SNAPSHOT-0edf307 linux/amd64 go1.21.1 (2023-10-04T08:46:49Z) 0edf3073bde5df29237ea91d6c624fcf9993d8e9
```