### PR TITLE
Refactor to allow easier use as library

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -5,15 +5,15 @@ import (
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/entry/load"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/stripe/stripe-go/v74"
 )
 
 var loadCmd = &cobra.Command{
 	Use:   "load",
 	Short: "Loads all data from Stripe and puts it in the DB",
 	Long:  "Loads all data from Stripe and puts it in the DB",
-	Run: func(cmd *cobra.Command, args []string) {
-		load.Start()
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cfg := config.GetStruct()
+		return load.Start(cmd.Context(), cfg)
 	},
 	PreRun: bindLoad,
 }
@@ -26,7 +26,5 @@ func init() {
 
 func bindLoad(cmd *cobra.Command, args []string) {
 	config.InitConfig()
-	stripe.Key = viper.GetString("stripe.api_key")
-
 	viper.BindPFlag("purge", cmd.Flags().Lookup("purge"))
 }

--- a/cmd/migrate/root.go
+++ b/cmd/migrate/root.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/entry/migrate"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -40,16 +41,18 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 	up := &cobra.Command{
 		Use:   "up",
 		Short: "Migrates the store to the latest version",
-		Run: func(cmd *cobra.Command, args []string) {
-			migrate.Migrate(datastoreName, "up", migrate.MigrateOpts{})
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg := config.GetStruct()
+			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "up", migrate.MigrateOpts{})
 		},
 	}
 
 	down := &cobra.Command{
 		Use:   "down",
 		Short: "Migrates the store to the earliest version",
-		Run: func(cmd *cobra.Command, args []string) {
-			migrate.Migrate(datastoreName, "down", migrate.MigrateOpts{})
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg := config.GetStruct()
+			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "down", migrate.MigrateOpts{})
 		},
 	}
 	down.Flags().Bool("danger", false, "Pass --danger to acknowledge this is potentially dangerous.")
@@ -58,24 +61,27 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 	version := &cobra.Command{
 		Use:   "version",
 		Short: "Prints the current version and \"dirty\" state",
-		Run: func(cmd *cobra.Command, args []string) {
-			migrate.Migrate(datastoreName, "version", migrate.MigrateOpts{})
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg := config.GetStruct()
+			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "version", migrate.MigrateOpts{})
 		},
 	}
 
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "Lists the migrations known to the application",
-		Run: func(cmd *cobra.Command, args []string) {
-			migrate.Migrate(datastoreName, "list", migrate.MigrateOpts{})
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg := config.GetStruct()
+			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "list", migrate.MigrateOpts{})
 		},
 	}
 
 	force := &cobra.Command{
 		Use:   "force",
 		Short: "Forces the migration state to the given version",
-		Run: func(cmd *cobra.Command, args []string) {
-			migrate.Migrate(datastoreName, "force", migrate.MigrateOpts{
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg := config.GetStruct()
+			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "force", migrate.MigrateOpts{
 				TargetVersion: getVersionFlagValue(cmd),
 			})
 		},
@@ -88,8 +94,9 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 	to := &cobra.Command{
 		Use:   "to",
 		Short: "Migrates to the given version (up or down)",
-		Run: func(cmd *cobra.Command, args []string) {
-			migrate.Migrate(datastoreName, "to", migrate.MigrateOpts{
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg := config.GetStruct()
+			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "to", migrate.MigrateOpts{
 				TargetVersion: getVersionFlagValue(cmd),
 			})
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"math/rand"
-	"os"
-	"time"
+	"context"
+	"io"
 
 	"github.com/friendlycaptcha/friendly-stripe-sync/cmd/migrate"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -20,12 +18,16 @@ var rootCmd = &cobra.Command{
 	PersistentPreRun: bindFlags,
 }
 
-func Execute() {
-	rand.Seed(time.Now().UnixNano())
-	if err := rootCmd.Execute(); err != nil {
-		log.Error().Err(err).Msg("Error executing root command")
-		os.Exit(1)
+func Execute(ctx context.Context, stdout io.Writer, args []string) error {
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(stdout)
+	rootCmd.SilenceUsage = true
+
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
+		return err
 	}
+
+	return nil
 }
 
 func init() {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -4,16 +4,15 @@ import (
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/entry/sync"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/stripe/stripe-go/v74"
 )
 
 var syncCmd = &cobra.Command{
 	Use:   "sync",
 	Short: "Loads changes from the last 30 days from Stripe and applies them to the DB",
 	Long:  "Loads changes from the last 30 days from Stripe and applies them to the DB",
-	Run: func(cmd *cobra.Command, args []string) {
-		sync.Start()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := config.GetStruct()
+		return sync.Start(cmd.Context(), cfg)
 	},
 	PreRun: bindSync,
 }
@@ -24,6 +23,4 @@ func init() {
 
 func bindSync(cmd *cobra.Command, args []string) {
 	config.InitConfig()
-
-	stripe.Key = viper.GetString("stripe.api_key")
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -5,15 +5,15 @@ import (
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/entry/watch"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/stripe/stripe-go/v74"
 )
 
 var watchCmd = &cobra.Command{
 	Use:   "watch",
 	Short: "Sync events from Stripe into the database on a fixed interval",
 	Long:  "Load the initial data if it hasn't been loaded already and periodically load events from Stripe to the database",
-	Run: func(cmd *cobra.Command, args []string) {
-		watch.Start()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := config.GetStruct()
+		return watch.Start(cmd.Context(), cfg)
 	},
 	PreRun: bindWatch,
 }
@@ -28,6 +28,4 @@ func bindWatch(cmd *cobra.Command, args []string) {
 	config.InitConfig()
 
 	viper.BindPFlag("stripe_sync.interval_seconds", cmd.Flags().Lookup("interval_seconds"))
-
-	stripe.Key = viper.GetString("stripe.api_key")
 }

--- a/internal/config/cfgmodel/postgres.go
+++ b/internal/config/cfgmodel/postgres.go
@@ -1,0 +1,38 @@
+package cfgmodel
+
+type FriendlyStripeSync struct {
+	Debug       bool `json:"debug"`
+	Purge       bool `json:"purge"`
+	Development bool `json:"development"`
+
+	Stripe     Stripe     `json:"stripe"`
+	Postgres   Postgres   `json:"postgres"`
+	StripeSync StripeSync `json:"stripe_sync"`
+
+	Logging Logging `json:"logging"`
+}
+
+type Stripe struct {
+	APIKey string `json:"api_key"`
+}
+
+type Postgres struct {
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	User     string `json:"user"`
+	Password string `json:"password"`
+	DBName   string `json:"dbname"`
+	SSLMode  string `json:"sslmode"`
+}
+
+type StripeSync struct {
+	IntervalSeconds int      `json:"interval_seconds"`
+	ExcludedFields  []string `json:"excluded_fields"`
+}
+
+type Logging struct {
+	Filename   string `json:"filename"`
+	MaxSize    int    `json:"max_size"`
+	MaxAge     int    `json:"max_age"`
+	MaxBackups int    `json:"max_backups"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
+
+	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config/cfgmodel"
 )
 
 var CfgFile string
@@ -43,4 +45,16 @@ func InitConfig() {
 	}
 
 	setupDefaults()
+}
+
+// GetStruct returns the config as a plain struct. You should call this after InitConfig.
+func GetStruct() cfgmodel.FriendlyStripeSync {
+	cfg := cfgmodel.FriendlyStripeSync{}
+
+	err := viper.Unmarshal(&cfg)
+	if err != nil {
+		panic("Failed to unmarshal config: " + err.Error())
+	}
+
+	return cfg
 }

--- a/internal/db/postgres/migrater.go
+++ b/internal/db/postgres/migrater.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 
+	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config/cfgmodel"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
@@ -63,13 +64,13 @@ func (mig *PostgresStoreMigrater) SetLogger(logger migrate.Logger) {
 	mig.m.Log = logger
 }
 
-func (pgs *PostgresStore) GetMigrater() (*PostgresStoreMigrater, error) {
+func (pgs *PostgresStore) GetMigrater(cfg cfgmodel.Postgres) (*PostgresStoreMigrater, error) {
 	d, err := iofs.New(migrationsFS, "migrations")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open Postgres migrations iofs: %w", err)
 	}
 
-	connString := BuildConnectionDSN(pgs.dbname)
+	connString := BuildConnectionDSN(cfg)
 	db, err := sql.Open("postgres", connString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open postgres db with postgres driver: %w", err)

--- a/internal/db/postgres/store.go
+++ b/internal/db/postgres/store.go
@@ -8,16 +8,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config/cfgmodel"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
-	"github.com/spf13/viper"
 )
 
-func BuildConnectionDSN(dbname string) string {
-	password := viper.GetString("postgres.password")
+func BuildConnectionDSN(cfg cfgmodel.Postgres) string {
+	password := cfg.Password
 
 	dsn := fmt.Sprintf("host=%s port=%d dbname=%s user=%s sslmode=%s",
-		viper.GetString("postgres.host"), viper.GetInt("postgres.port"), dbname, viper.GetString("postgres.user"), viper.GetString("postgres.sslmode"))
+		cfg.Host, cfg.Port, cfg.DBName, cfg.User, cfg.SSLMode)
 
 	if password != "" {
 		dsn += " password=" + password
@@ -27,14 +27,12 @@ func BuildConnectionDSN(dbname string) string {
 }
 
 type PostgresStore struct {
-	db     *sqlx.DB
-	Q      *Queries
-	dbname string
+	db *sqlx.DB
+	Q  *Queries
 }
 
-func NewPostgresStore() *PostgresStore {
-	dbname := viper.GetString("postgres.dbname")
-	db, err := sqlx.Open("postgres", BuildConnectionDSN(dbname))
+func NewPostgresStore(cfg cfgmodel.Postgres) *PostgresStore {
+	db, err := sqlx.Open("postgres", BuildConnectionDSN(cfg))
 	if err != nil {
 		log.Fatalf("Failed to connect to postgres store: %v", err)
 	}
@@ -44,16 +42,14 @@ func NewPostgresStore() *PostgresStore {
 	db.SetConnMaxLifetime(time.Hour * 1)
 
 	return &PostgresStore{
-		db:     db,
-		Q:      New(db),
-		dbname: dbname,
+		db: db,
+		Q:  New(db),
 	}
 }
 
-func NewPostgresTestStore() (*PostgresStore, func()) {
+func NewPostgresTestStore(cfg cfgmodel.Postgres) (*PostgresStore, func()) {
 	// We first need to authenticate against the ordinary dbname
-	dbname := viper.GetString("postgres.dbname")
-	dbBootstrap, err := sqlx.Open("postgres", BuildConnectionDSN(dbname))
+	dbBootstrap, err := sqlx.Open("postgres", BuildConnectionDSN(cfg))
 	if err != nil {
 		log.Fatalf("Failed to connect to postgres bootstrap store: %v", err)
 	}
@@ -62,13 +58,16 @@ func NewPostgresTestStore() (*PostgresStore, func()) {
 	if _, err := rand.Read(b); err != nil {
 		panic(err)
 	}
-	dbname = "friendly_stripe_sync_test_" + strings.ToLower(fmt.Sprintf("%X", b))
-	_, err = dbBootstrap.Exec(`CREATE DATABASE ` + dbname + `;`)
+
+	cfgTest := cfg // Copy the config
+	cfgTest.DBName = "friendly_stripe_sync_test_" + strings.ToLower(fmt.Sprintf("%X", b))
+
+	_, err = dbBootstrap.Exec(`CREATE DATABASE ` + cfg.DBName + `;`)
 	if err != nil {
 		log.Fatalf("Couldn't create Postgres test DB: %v", err)
 	}
 
-	db, err := sqlx.Open("postgres", BuildConnectionDSN(dbname))
+	db, err := sqlx.Open("postgres", BuildConnectionDSN(cfgTest))
 	if err != nil {
 		log.Fatalf("Failed to connect to postgres test store: %v", err)
 	}
@@ -79,7 +78,7 @@ func NewPostgresTestStore() (*PostgresStore, func()) {
 			os.Exit(-5)
 		}
 
-		_, err = dbBootstrap.Exec(fmt.Sprintf("DROP DATABASE %s", dbname))
+		_, err = dbBootstrap.Exec(fmt.Sprintf("DROP DATABASE %s", cfgTest.DBName))
 		if err != nil {
 			log.Fatalf("Couldn't DROP db: %v", err)
 		}
@@ -92,11 +91,10 @@ func NewPostgresTestStore() (*PostgresStore, func()) {
 	}
 
 	store := &PostgresStore{
-		db:     db,
-		Q:      New(db),
-		dbname: dbname,
+		db: db,
+		Q:  New(db),
 	}
-	mig, err := store.GetMigrater()
+	mig, err := store.GetMigrater(cfgTest)
 	if err != nil {
 		log.Printf("Failed to get postgres migrater: %v\n", err)
 		cleanup()

--- a/internal/db/postgres/store.go
+++ b/internal/db/postgres/store.go
@@ -23,7 +23,6 @@ func BuildConnectionDSN(cfg cfgmodel.Postgres) string {
 		dsn += " password=" + password
 	}
 	return dsn
-
 }
 
 type PostgresStore struct {
@@ -31,10 +30,10 @@ type PostgresStore struct {
 	Q  *Queries
 }
 
-func NewPostgresStore(cfg cfgmodel.Postgres) *PostgresStore {
+func NewPostgresStore(cfg cfgmodel.Postgres) (*PostgresStore, error) {
 	db, err := sqlx.Open("postgres", BuildConnectionDSN(cfg))
 	if err != nil {
-		log.Fatalf("Failed to connect to postgres store: %v", err)
+		return nil, fmt.Errorf("Failed to connect to postgres store: %w", err)
 	}
 
 	db.SetMaxIdleConns(20)
@@ -44,7 +43,7 @@ func NewPostgresStore(cfg cfgmodel.Postgres) *PostgresStore {
 	return &PostgresStore{
 		db: db,
 		Q:  New(db),
-	}
+	}, nil
 }
 
 func NewPostgresTestStore(cfg cfgmodel.Postgres) (*PostgresStore, func()) {

--- a/internal/entry/load/load.go
+++ b/internal/entry/load/load.go
@@ -13,11 +13,14 @@ import (
 func Start(ctx context.Context, cfg cfgmodel.FriendlyStripeSync) error {
 	telemetry.SetupLogger(cfg.Development, cfg.Debug, cfg.Logging)
 
-	db := postgres.NewPostgresStore(cfg.Postgres)
+	db, err := postgres.NewPostgresStore(cfg.Postgres)
+	if err != nil {
+		return fmt.Errorf("failed to create postgres store: %w", err)
+	}
 
 	stripesync := ops.New(db, cfg.StripeSync, cfg.Stripe.APIKey)
 
-	err := stripesync.InitialLoad(ctx, cfg.Purge)
+	err = stripesync.InitialLoad(ctx, cfg.Purge)
 	if err != nil {
 		return fmt.Errorf("failed to load initial data: %w", err)
 	}

--- a/internal/entry/load/load.go
+++ b/internal/entry/load/load.go
@@ -1,20 +1,26 @@
 package load
 
 import (
-	"github.com/rs/zerolog/log"
+	"context"
+	"fmt"
 
+	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config/cfgmodel"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/db/postgres"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/ops"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/telemetry"
 )
 
-func Start() {
-	telemetry.SetupLogger()
+func Start(ctx context.Context, cfg cfgmodel.FriendlyStripeSync) error {
+	telemetry.SetupLogger(cfg.Development, cfg.Debug, cfg.Logging)
 
-	db := postgres.NewPostgresStore()
+	db := postgres.NewPostgresStore(cfg.Postgres)
 
-	err := ops.InititalLoad(db)
+	stripesync := ops.New(db, cfg.StripeSync, cfg.Stripe.APIKey)
+
+	err := stripesync.InitialLoad(ctx, cfg.Purge)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to load initial data")
+		return fmt.Errorf("failed to load initial data: %w", err)
 	}
+
+	return nil
 }

--- a/internal/entry/migrate/migrate.go
+++ b/internal/entry/migrate/migrate.go
@@ -3,7 +3,6 @@ package migrate
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config/cfgmodel"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/db/postgres"
@@ -32,11 +31,13 @@ func Migrate(ctx context.Context, cfg cfgmodel.FriendlyStripeSync, storeName str
 
 	switch storeName {
 	case "postgres":
-		pg := postgres.NewPostgresStore(cfg.Postgres)
+		pg, err := postgres.NewPostgresStore(cfg.Postgres)
+		if err != nil {
+			return fmt.Errorf("failed to create postgres store: %w", err)
+		}
 		pgMigrater, err := pg.GetMigrater(cfg.Postgres)
 		if err != nil {
-			l.Error().Err(err).Msg("Failed to get migrater")
-			os.Exit(1)
+			return fmt.Errorf("failed to get migrater: %w", err)
 		}
 		migrater = pgMigrater
 		defer migrater.Close()

--- a/internal/entry/sync/sync.go
+++ b/internal/entry/sync/sync.go
@@ -13,11 +13,14 @@ import (
 func Start(ctx context.Context, cfg cfgmodel.FriendlyStripeSync) error {
 	telemetry.SetupLogger(cfg.Development, cfg.Debug, cfg.Logging)
 
-	db := postgres.NewPostgresStore(cfg.Postgres)
+	db, err := postgres.NewPostgresStore(cfg.Postgres)
+	if err != nil {
+		return fmt.Errorf("failed to create postgres store: %w", err)
+	}
 
 	stripesync := ops.New(db, cfg.StripeSync, cfg.Stripe.APIKey)
 
-	err := stripesync.SyncEvents(ctx)
+	err = stripesync.SyncEvents(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to sync events: %w", err)
 	}

--- a/internal/entry/sync/sync.go
+++ b/internal/entry/sync/sync.go
@@ -1,19 +1,26 @@
 package sync
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config/cfgmodel"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/db/postgres"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/ops"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/telemetry"
-	"github.com/rs/zerolog/log"
 )
 
-func Start() {
-	telemetry.SetupLogger()
+func Start(ctx context.Context, cfg cfgmodel.FriendlyStripeSync) error {
+	telemetry.SetupLogger(cfg.Development, cfg.Debug, cfg.Logging)
 
-	db := postgres.NewPostgresStore()
+	db := postgres.NewPostgresStore(cfg.Postgres)
 
-	err := ops.SyncEvents(db)
+	stripesync := ops.New(db, cfg.StripeSync, cfg.Stripe.APIKey)
+
+	err := stripesync.SyncEvents(ctx)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to sync events")
+		return fmt.Errorf("failed to sync events: %w", err)
 	}
+
+	return nil
 }

--- a/internal/entry/watch/watch.go
+++ b/internal/entry/watch/watch.go
@@ -21,11 +21,14 @@ func Start(ctx context.Context, cfg cfgmodel.FriendlyStripeSync) error {
 
 	intervalSeconds := cfg.StripeSync.IntervalSeconds
 
-	db := postgres.NewPostgresStore(cfg.Postgres)
+	db, err := postgres.NewPostgresStore(cfg.Postgres)
+	if err != nil {
+		return fmt.Errorf("failed to create postgres store: %w", err)
+	}
 
 	stripesync := ops.New(db, cfg.StripeSync, cfg.Stripe.APIKey)
 
-	_, err := db.Q.GetCurrentSyncState(ctx)
+	_, err = db.Q.GetCurrentSyncState(ctx)
 	if err == sql.ErrNoRows {
 		log.Info().Msg("No sync state found, doing an initial load")
 		err := stripesync.InitialLoad(ctx, cfg.Purge)

--- a/internal/entry/watch/watch.go
+++ b/internal/entry/watch/watch.go
@@ -3,37 +3,37 @@ package watch
 import (
 	"context"
 	"database/sql"
-	"os"
-	"os/signal"
-	"syscall"
+	"fmt"
 	"time"
 
+	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config/cfgmodel"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/db/postgres"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/ops"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/telemetry"
 	"github.com/rs/zerolog/log"
-	"github.com/spf13/viper"
 )
 
-func Start() {
-	telemetry.SetupLogger()
+func Start(ctx context.Context, cfg cfgmodel.FriendlyStripeSync) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	intervalSeconds := viper.GetInt("stripe_sync.interval_seconds")
+	telemetry.SetupLogger(cfg.Development, cfg.Debug, cfg.Logging)
 
-	sc := make(chan os.Signal, 1)
-	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
+	intervalSeconds := cfg.StripeSync.IntervalSeconds
 
-	db := postgres.NewPostgresStore()
+	db := postgres.NewPostgresStore(cfg.Postgres)
 
-	_, err := db.Q.GetCurrentSyncState(context.Background())
+	stripesync := ops.New(db, cfg.StripeSync, cfg.Stripe.APIKey)
+
+	_, err := db.Q.GetCurrentSyncState(ctx)
 	if err == sql.ErrNoRows {
 		log.Info().Msg("No sync state found, doing an initial load")
-		err := ops.InititalLoad(db)
+		err := stripesync.InitialLoad(ctx, cfg.Purge)
 		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to load initial data")
+			return fmt.Errorf("failed to load initial data: %w", err)
 		}
 	} else if err != nil {
-		log.Fatal().Err(err).Msg("Failed to get latest sync state")
+		return fmt.Errorf("failed to get latest sync state: %w", err)
 	}
 
 	log.Info().Msgf("Starting to sync events every %d seconds", intervalSeconds)
@@ -41,11 +41,11 @@ func Start() {
 	ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
 	for {
 		select {
-		case <-sc:
+		case <-ctx.Done():
 			ticker.Stop()
-			return
+			return nil
 		case <-ticker.C:
-			err := ops.SyncEvents(db)
+			err := stripesync.SyncEvents(ctx)
 			if err != nil {
 				log.Error().Err(err).Msg("Failed to sync events")
 			}

--- a/internal/ops/events.go
+++ b/internal/ops/events.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/friendlycaptcha/friendly-stripe-sync/internal/db/postgres"
 	"github.com/rs/zerolog/log"
 	"github.com/stripe/stripe-go/v74"
 )
@@ -18,60 +17,60 @@ func unmarshalEventData[T interface{}](e *stripe.Event) (*T, error) {
 	return &data, err
 }
 
-func HandleEvent(c context.Context, db *postgres.PostgresStore, e *stripe.Event) error {
+func (o *Ops) HandleEvent(c context.Context, e *stripe.Event) error {
 	switch e.Type {
 	case "customer.created", "customer.updated", "customer.deleted":
 		customer, err := unmarshalEventData[stripe.Customer](e)
 		if err == nil {
-			return HandleCustomerUpdated(c, db, customer)
+			return o.HandleCustomerUpdated(c, customer)
 		}
 		break
 	case "product.created", "product.updated":
 		product, err := unmarshalEventData[stripe.Product](e)
 		if err == nil {
-			return HandleProductUpdated(c, db, product)
+			return o.HandleProductUpdated(c, product)
 		}
 		break
 	case "product.deleted":
 		product, err := unmarshalEventData[stripe.Product](e)
 		if err == nil {
-			return HandleProductDeleted(c, db, product)
+			return o.HandleProductDeleted(c, product)
 		}
 		break
 	case "customer.subscription.created", "customer.subscription.updated", "customer.subscription.deleted", "customer.subscription.paused":
 		subscription, err := unmarshalEventData[stripe.Subscription](e)
 		if err == nil {
-			return HandleSubscriptionUpdated(c, db, subscription)
+			return o.HandleSubscriptionUpdated(c, subscription)
 		}
 		break
 	case "price.created", "price.updated":
 		price, err := unmarshalEventData[stripe.Price](e)
 		if err == nil {
-			return HandlePriceUpdated(c, db, price)
+			return o.HandlePriceUpdated(c, price)
 		}
 		break
 	case "price.deleted":
 		price, err := unmarshalEventData[stripe.Price](e)
 		if err == nil {
-			return HandlePriceDeleted(c, db, price)
+			return o.HandlePriceDeleted(c, price)
 		}
 		break
 	case "coupon.created", "coupon.updated":
 		coupon, err := unmarshalEventData[stripe.Coupon](e)
 		if err == nil {
-			return HandleCouponUpdated(c, db, coupon)
+			return o.HandleCouponUpdated(c, coupon)
 		}
 		break
 	case "coupon.deleted":
 		coupon, err := unmarshalEventData[stripe.Coupon](e)
 		if err == nil {
-			return HandleCouponDeleted(c, db, coupon)
+			return o.HandleCouponDeleted(c, coupon)
 		}
 		break
 	case "customer.discount.updated", "customer.discount.deleted":
 		discount, err := unmarshalEventData[stripe.Discount](e)
 		if err == nil {
-			return HandleSubscriptionDiscountUpdated(c, db, discount)
+			return o.HandleSubscriptionDiscountUpdated(c, discount)
 		}
 		break
 	}

--- a/internal/ops/ops.go
+++ b/internal/ops/ops.go
@@ -1,0 +1,26 @@
+package ops
+
+import (
+	"github.com/friendlycaptcha/friendly-stripe-sync/internal/config/cfgmodel"
+	"github.com/friendlycaptcha/friendly-stripe-sync/internal/db/postgres"
+	"github.com/stripe/stripe-go/v74/client"
+)
+
+// Ops is a struct that holds the common global state for all operations.
+type Ops struct {
+	db     *postgres.PostgresStore
+	cfg    cfgmodel.StripeSync
+	stripe *client.API
+}
+
+// New creates a new Ops struct.
+func New(pg *postgres.PostgresStore, cfg cfgmodel.StripeSync, stripeAPIKey string) *Ops {
+	stripeClient := &client.API{}
+	stripeClient.Init(stripeAPIKey, nil)
+
+	return &Ops{
+		db:     pg,
+		cfg:    cfg,
+		stripe: stripeClient,
+	}
+}

--- a/internal/ops/prices.go
+++ b/internal/ops/prices.go
@@ -3,19 +3,19 @@ package ops
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/db/postgres"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/utils"
 	"github.com/stripe/stripe-go/v74"
-	"github.com/stripe/stripe-go/v74/price"
 )
 
-func HandlePriceUpdated(c context.Context, db *postgres.PostgresStore, price *stripe.Price) error {
-	err := EnsureProductLoaded(c, db, price.Product.ID)
+func (o *Ops) HandlePriceUpdated(c context.Context, price *stripe.Price) error {
+	err := o.EnsureProductLoaded(c, price.Product.ID)
 	if err != nil {
 		return err
 	}
-	return db.Q.UpsertPrice(c, postgres.UpsertPriceParams{
+	return o.db.Q.UpsertPrice(c, postgres.UpsertPriceParams{
 		ID:                price.ID,
 		Object:            price.Object,
 		Active:            price.Active,
@@ -36,21 +36,24 @@ func HandlePriceUpdated(c context.Context, db *postgres.PostgresStore, price *st
 	})
 }
 
-func HandlePriceDeleted(c context.Context, db *postgres.PostgresStore, price *stripe.Price) error {
-	return db.Q.DeleteProduct(c, price.ID)
+func (o *Ops) HandlePriceDeleted(c context.Context, price *stripe.Price) error {
+	return o.db.Q.DeleteProduct(c, price.ID)
 }
 
-func EnsurePriceLoaded(c context.Context, db *postgres.PostgresStore, priceID string) error {
-	exists, err := db.Q.PriceExists(c, priceID)
+func (o *Ops) EnsurePriceLoaded(c context.Context, priceID string) error {
+	exists, err := o.db.Q.PriceExists(c, priceID)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		price, err := price.Get(priceID, nil)
+		price, err := o.stripe.Prices.Get(priceID, nil)
 		if err != nil {
 			return err
 		}
-		HandlePriceUpdated(c, db, price)
+		err = o.HandlePriceUpdated(c, price)
+		if err != nil {
+			return fmt.Errorf("failed to upsert price: %w", err)
+		}
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -1,9 +1,29 @@
 package main
 
 import (
+	"context"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/friendlycaptcha/friendly-stripe-sync/cmd"
 )
 
+func run(ctx context.Context, w io.Writer, args []string) error {
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	err := cmd.Execute(ctx, w, args)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func main() {
-	cmd.Execute()
+	ctx := context.Background()
+	if err := run(ctx, os.Stdout, os.Args[1:]); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This allows one to use this project as a library, while (hopefully) not changing anything about its use as a CLI tool.

Overview of changes:
* A `context.Context` is piped all the way through, which for the CLI is created in `main` (which carries interrupt signals).
* Entrypoints now return an `error` rather than having some `log.Fatal` here and there.
* No more use of `viper` in the app aside from the CLI entrypoints: a plain struct is passed down.
* Remove use of global `stripe.Key`
* Introduce a struct to keep some state (pg client, stripe client, some of the config).