### PR TITLE
Handle `customer.discount.deleted` edge case

### DIFF
--- a/stripesync/events.go
+++ b/stripesync/events.go
@@ -59,10 +59,15 @@ func (o *StripeSync) handleEvent(c context.Context, e *stripe.Event) error {
 		if err == nil {
 			return o.handleCouponDeleted(c, coupon)
 		}
-	case "customer.discount.updated", "customer.discount.deleted":
+	case "customer.discount.updated":
 		discount, err := unmarshalEventData[stripe.Discount](e)
 		if err == nil {
 			return o.handleSubscriptionDiscountUpdated(c, discount)
+		}
+	case "customer.discount.deleted":
+		discount, err := unmarshalEventData[stripe.Discount](e)
+		if err == nil {
+			return o.handleSubscriptionDiscountDeleted(c, discount)
 		}
 	}
 	return nil

--- a/stripesync/subscriptions.go
+++ b/stripesync/subscriptions.go
@@ -106,7 +106,14 @@ func (o *StripeSync) handleSubscriptionDiscountUpdated(c context.Context, discou
 	if err != nil {
 		return err
 	}
+	return o.updateSubscriptionDiscount(c, discount)
+}
 
+func (o *StripeSync) handleSubscriptionDiscountDeleted(c context.Context, discount *stripe.Discount) error {
+	return o.updateSubscriptionDiscount(c, discount)
+}
+
+func (o *StripeSync) updateSubscriptionDiscount(c context.Context, discount *stripe.Discount) error {
 	var promotionCodeID sql.NullString
 	if discount.PromotionCode != nil {
 		promotionCodeID = sql.NullString{


### PR DESCRIPTION
Handles the case where a deleted event references a coupon that doesn't exist any more. Same logic as the update path but we just don't ensure that the coupon is present in the DB.