### PR TITLE
Add support for multihost postgres connection strings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ stripe:
 
 # Database configuration
 postgres:
-  host: "localhost"
+  host: "localhost" # can be a comma-separated list (eg, "10.0.0.1,10.0.0.2")
   port: 5432
   user: "postgres"
   password: ""

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,17 @@
 module github.com/friendlycaptcha/friendly-stripe-sync
 
-go 1.18
+go 1.23
 
 require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/jmoiron/sqlx v1.3.1
-	github.com/lib/pq v1.10.0
+	github.com/lib/pq v1.12.3
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rs/zerolog v1.28.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	github.com/sqlc-dev/pqtype v0.3.0
+	github.com/stretchr/testify v1.9.0
 	github.com/stripe/stripe-go/v74 v74.3.0
 	golang.org/x/sync v0.1.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
@@ -35,7 +36,6 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -404,6 +404,7 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -563,6 +564,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-github/v39 v39.2.0/go.mod h1:C1s8C5aCC9L+JXIYpJM5GYytdX52vC1bLvHEF1IhBrE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -759,6 +761,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
@@ -771,8 +774,9 @@ github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/lib/pq v1.10.0 h1:Zx5DJFEYQXio93kgXnQ09fXNiUKsqv4OUEu2UtGcB1E=
 github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -988,6 +992,7 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
@@ -1073,7 +1078,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stripe/stripe-go/v74 v74.3.0 h1:8ymGwZvMnpWMCRNomc9dVGcJ5j8L/ubwhQvpIpcmcOA=
@@ -1713,6 +1717,7 @@ google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20220111164026-67b88f271998/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220314164441-57ef72a4c106/go.mod h1:hAL49I2IFola2sVEjAn7MEwsja0xp51I0tlGAf9hz4E=
 google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e h1:S9GbmC1iCgvbLyAokVCwiO6tVIrU9Y7c5oMx1V/ki/Y=
+google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e/go.mod h1:9qHF0xnpdSfF6knlcsnpzUu5y+rpwgbvsyGAZPBMg4s=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -1747,6 +1752,7 @@ google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ5
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/grpc v1.50.1 h1:DS/BukOZWp8s6p4Dt/tOaJaTQyPyOoCcrjroHuCeLzY=
+google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -1762,6 +1768,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/db/postgres/migrater.go
+++ b/internal/db/postgres/migrater.go
@@ -64,6 +64,9 @@ func (mig *PostgresStoreMigrater) SetLogger(logger migrate.Logger) {
 }
 
 func (pgs *Store) GetMigrater(cfg Config) (*PostgresStoreMigrater, error) {
+	if err := validateHostList(cfg.Host); err != nil {
+		return nil, fmt.Errorf("invalid postgres host %q: %w", cfg.Host, err)
+	}
 	d, err := iofs.New(migrationsFS, "migrations")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open Postgres migrations iofs: %w", err)

--- a/internal/db/postgres/store.go
+++ b/internal/db/postgres/store.go
@@ -1,27 +1,44 @@
 package postgres
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
 	"os"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 )
 
-func BuildConnectionDSN(cfg Config) string {
-	password := cfg.Password
+const defaultTargetSessionAttrs = "read-write"
 
-	dsn := fmt.Sprintf("host=%s port=%d dbname=%s user=%s sslmode=%s",
+func BuildConnectionDSN(cfg Config) string {
+	dsn := fmt.Sprintf("host=%s port=%d dbname=%s user=%s sslmode=%s connect_timeout=4",
 		cfg.Host, cfg.Port, cfg.DBName, cfg.User, cfg.SSLMode)
 
-	if password != "" {
-		dsn += " password=" + password
+	if cfg.Password != "" {
+		dsn += " password=" + cfg.Password
 	}
+
+	dsn += " target_session_attrs=" + defaultTargetSessionAttrs
 	return dsn
+}
+
+// validateHostList accepts a single host or a comma-separated list with no whitespace (eg, "10.0.0.1,10.0.0.2").
+func validateHostList(host string) error {
+	if strings.ContainsFunc(host, unicode.IsSpace) {
+		return errors.New("must not contain whitespace; use a host or comma-separated host list")
+	}
+	for _, h := range strings.Split(host, ",") {
+		if h == "" {
+			return errors.New("must be a host or comma-separated host list")
+		}
+	}
+	return nil
 }
 
 type Store struct {
@@ -39,6 +56,9 @@ type Config struct {
 }
 
 func NewPostgresStore(cfg Config) (*Store, error) {
+	if err := validateHostList(cfg.Host); err != nil {
+		return nil, fmt.Errorf("invalid postgres host %q: %w", cfg.Host, err)
+	}
 	db, err := sqlx.Open("postgres", BuildConnectionDSN(cfg))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to connect to postgres store: %w", err)
@@ -46,7 +66,7 @@ func NewPostgresStore(cfg Config) (*Store, error) {
 
 	db.SetMaxIdleConns(20)
 	db.SetMaxOpenConns(80)
-	db.SetConnMaxLifetime(time.Hour * 1)
+	db.SetConnMaxLifetime(time.Minute * 15)
 
 	return &Store{
 		db: db,

--- a/internal/db/postgres/store_test.go
+++ b/internal/db/postgres/store_test.go
@@ -1,0 +1,48 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateHostList(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		isValid bool
+	}{
+		{"single host", "localhost", true},
+		{"comma-separated", "10.0.0.1,10.0.0.2", true},
+		{"whitespace", "10.0.0.1, 10.0.0.2", false},
+		{"trailing comma", "10.0.0.1,", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHostList(tt.host)
+			if tt.isValid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestBuildConnectionDSN(t *testing.T) {
+	dsn := BuildConnectionDSN(Config{
+		Host:    "10.0.0.1,10.0.0.2",
+		Port:    5432,
+		DBName:  "friendlystripe",
+		User:    "postgres",
+		SSLMode: "disable",
+	})
+	for _, want := range []string{
+		"host=10.0.0.1,10.0.0.2",
+		"target_session_attrs=read-write",
+		"connect_timeout=4",
+	} {
+		assert.Contains(t, dsn, want)
+	}
+}

--- a/stripesync/stripesync_test.go
+++ b/stripesync/stripesync_test.go
@@ -29,13 +29,12 @@ func TestSmoke(t *testing.T) {
 		},
 	})
 
-	if strings.Contains(err.Error(), "connect: connection refused") {
-		t.Skip("Postgres not running or configured, run `docker compose up`")
-	}
-
 	require.NoError(t, err)
 
 	err = syncer.MigrateDB(ctx)
+	if err != nil && strings.Contains(err.Error(), "connection refused") {
+		t.Skip("Postgres not running or configured, run `docker compose up`")
+	}
 	require.NoError(t, err)
 
 	ss, err := syncer.GetCurrentSyncState(ctx)


### PR DESCRIPTION
Adds support for multihost postgres connection strings:

- https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS
- https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-TARGET-SESSION-ATTRS

Also includes a fix to `stripesync/stripesync_test.go`. Running `go test ./...` fails for me on `main`. Think it's because `New()` doesn't actually connect to the database (just sets up the connection object), so if the config is correct then `err` is always `nil` regardless of if postgres is running or not. So when the code calls `strings.Contains(err.Error() ...)` then we get a nil deref. 

```console
$ go test ./...
?       github.com/friendlycaptcha/friendly-stripe-sync [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/cmd     [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/cmd/migrate     [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/example [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/buildinfo      [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/cfgmodel       [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/config [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/db/postgres    [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/entry/load     [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/entry/migrate  [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/entry/sync     [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/entry/watch    [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/store  [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/telemetry      [no test files]
?       github.com/friendlycaptcha/friendly-stripe-sync/internal/utils  [no test files]
--- FAIL: TestSmoke (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x75e3c7]

goroutine 8 [running]:
testing.tRunner.func1.2({0x83d4a0, 0xc6d340})
        /usr/local/go/src/testing/testing.go:1974 +0x232
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1977 +0x349
panic({0x83d4a0?, 0xc6d340?})
        /usr/local/go/src/runtime/panic.go:860 +0x13a
github.com/friendlycaptcha/friendly-stripe-sync/stripesync_test.TestSmoke(0x36845a6a4b48)
        /friendly-stripe-sync/stripesync/stripesync_test.go:32 +0x1c7
testing.tRunner(0x36845a6a4b48, 0x915f98)
        /usr/local/go/src/testing/testing.go:2036 +0xea
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:2101 +0x4c5
FAIL    github.com/friendlycaptcha/friendly-stripe-sync/stripesync      0.004s
FAIL
```