### PR TITLE
Handle missing coupons in ensureCouponLoaded

### DIFF
--- a/stripesync/coupons.go
+++ b/stripesync/coupons.go
@@ -3,10 +3,12 @@ package stripesync
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/db/postgres"
 	"github.com/friendlycaptcha/friendly-stripe-sync/internal/utils"
+	"github.com/rs/zerolog/log"
 	"github.com/stripe/stripe-go/v74"
 )
 
@@ -45,18 +47,29 @@ func (o *StripeSync) handleCouponDeleted(c context.Context, coupon *stripe.Coupo
 	return o.db.Q.DeleteCoupon(c, coupon.ID)
 }
 
-func (o *StripeSync) ensureCouponLoaded(c context.Context, couponID string) error {
+// ensureCouponLoaded makes sure the coupon is in the database, fetching it from Stripe if needed.
+// It reports whether the coupon is present afterwards: coupons are deleted permanently in Stripe,
+// so one that is already gone can never be loaded and callers must not reference it.
+func (o *StripeSync) ensureCouponLoaded(c context.Context, couponID string) (bool, error) {
 	exists, err := o.db.Q.CouponExists(c, couponID)
 	if err != nil {
-		return err
-	}
-	if !exists {
-		// HandleCouponUpdated will fetch the coupon from Stripe because AppliesTo isn't set
-		err = o.handleCouponUpdated(c, &stripe.Coupon{ID: couponID})
-		if err != nil {
-			return fmt.Errorf("failed to upsert coupon: %w", err)
-		}
+		return false, err
 	}
 
-	return nil
+	if exists {
+		return true, nil
+	}
+
+	// HandleCouponUpdated will fetch the coupon from Stripe because AppliesTo isn't set
+	err = o.handleCouponUpdated(c, &stripe.Coupon{ID: couponID})
+	if err != nil {
+		var stripeErr *stripe.Error
+		if errors.As(err, &stripeErr) && stripeErr.Code == stripe.ErrorCodeResourceMissing {
+			log.Info().Str("coupon_id", couponID).Msg("Skipping coupon that no longer exists in Stripe")
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to upsert coupon: %w", err)
+	}
+
+	return true, nil
 }

--- a/stripesync/subscriptions.go
+++ b/stripesync/subscriptions.go
@@ -25,15 +25,19 @@ func (o *StripeSync) handleSubscriptionUpdated(ctx context.Context, subscription
 		discountID = utils.StringToNullString(subscription.Discount.ID)
 		discountStart = utils.Int64ToNullInt64(subscription.Discount.Start)
 		discountEnd = utils.Int64ToNullInt64(subscription.Discount.End)
-		discountCoupon = utils.StringToNullString(subscription.Discount.Coupon.ID)
 		discountDeleted = sql.NullBool{Bool: subscription.Discount.Deleted, Valid: true}
 		if subscription.Discount.PromotionCode != nil {
 			discountPromotionCode = utils.StringToNullString(subscription.Discount.PromotionCode.ID)
 		}
 
-		err := o.ensureCouponLoaded(ctx, subscription.Discount.Coupon.ID)
+		loaded, err := o.ensureCouponLoaded(ctx, subscription.Discount.Coupon.ID)
 		if err != nil {
 			return err
+		}
+		// Only reference the coupon if we actually have it: it may have been deleted in Stripe
+		// already, in which case there is no row to point the foreign key at.
+		if loaded {
+			discountCoupon = utils.StringToNullString(subscription.Discount.Coupon.ID)
 		}
 	}
 
@@ -102,7 +106,7 @@ func (o *StripeSync) handleSubscriptionUpdated(ctx context.Context, subscription
 }
 
 func (o *StripeSync) handleSubscriptionDiscountUpdated(c context.Context, discount *stripe.Discount) error {
-	err := o.ensureCouponLoaded(c, discount.Coupon.ID)
+	loaded, err := o.ensureCouponLoaded(c, discount.Coupon.ID)
 	if err != nil {
 		return err
 	}
@@ -115,8 +119,10 @@ func (o *StripeSync) handleSubscriptionDiscountUpdated(c context.Context, discou
 		}
 	}
 
+	// Only reference the coupon if we actually have it: it may have been deleted in Stripe
+	// already, in which case there is no row to point the foreign key at.
 	var couponID sql.NullString
-	if discount.Coupon != nil {
+	if discount.Coupon != nil && loaded {
 		couponID = sql.NullString{
 			Valid:  true,
 			String: discount.Coupon.ID,

--- a/stripesync/subscriptions.go
+++ b/stripesync/subscriptions.go
@@ -122,7 +122,7 @@ func (o *StripeSync) handleSubscriptionDiscountUpdated(c context.Context, discou
 	// Only reference the coupon if we actually have it: it may have been deleted in Stripe
 	// already, in which case there is no row to point the foreign key at.
 	var couponID sql.NullString
-	if discount.Coupon != nil && loaded {
+	if loaded {
 		couponID = sql.NullString{
 			Valid:  true,
 			String: discount.Coupon.ID,


### PR DESCRIPTION
Although we gracefully handle deleted coupons [here](https://github.com/FriendlyCaptcha/friendly-stripe-sync/blob/handle-missing-coupons/stripesync/sync.go#L104), the code path for handling subscription and subscription discount events can still attempt to load missing coupons through [ensureCouponLoaded](https://github.com/FriendlyCaptcha/friendly-stripe-sync/compare/handle-missing-coupons?expand=1#diff-7fc777240ab769c8d874b9fed3bedd22a427994c618cac0e3f9f33d7465d8060L48). 

Update ensureCouponLoaded to detect the explicit resource missing error and return a flag indicating when this is the case.