### PR TITLE
CLI config fixes

### DIFF
--- a/cmd/migrate/root.go
+++ b/cmd/migrate/root.go
@@ -121,9 +121,9 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 	return r
 }
 
-// bindMigrate is a PreRun rather than a PersistentPreRun on the migrate root
-// because cobra only runs the closest PersistentPreRun, which would shadow the
-// root command's global flag binding.
+// bindMigrate loads the config before a migrate subcommand runs. It needs to be
+// PreRun, because refactoring it to PersistentPreRun would stop cobra running
+// the top-level bindFlags hook (i.e., --development and --debug flags).
 func bindMigrate(_ *cobra.Command, _ []string) {
 	config.InitConfig()
 }

--- a/cmd/migrate/root.go
+++ b/cmd/migrate/root.go
@@ -45,6 +45,7 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 			cfg := config.GetStruct()
 			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "up", migrate.MigrateOpts{})
 		},
+		PreRun: bindMigrate,
 	}
 
 	down := &cobra.Command{
@@ -54,6 +55,7 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 			cfg := config.GetStruct()
 			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "down", migrate.MigrateOpts{})
 		},
+		PreRun: bindMigrate,
 	}
 	down.Flags().Bool("danger", false, "Pass --danger to acknowledge this is potentially dangerous.")
 	down.MarkFlagRequired("danger")
@@ -65,6 +67,7 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 			cfg := config.GetStruct()
 			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "version", migrate.MigrateOpts{})
 		},
+		PreRun: bindMigrate,
 	}
 
 	list := &cobra.Command{
@@ -74,6 +77,7 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 			cfg := config.GetStruct()
 			return migrate.Migrate(cmd.Context(), cfg, datastoreName, "list", migrate.MigrateOpts{})
 		},
+		PreRun: bindMigrate,
 	}
 
 	force := &cobra.Command{
@@ -85,6 +89,7 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 				TargetVersion: getVersionFlagValue(cmd),
 			})
 		},
+		PreRun: bindMigrate,
 	}
 	force.Flags().Int("version", 9999, "Version to set the state to")
 	force.MarkFlagRequired("version")
@@ -100,6 +105,7 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 				TargetVersion: getVersionFlagValue(cmd),
 			})
 		},
+		PreRun: bindMigrate,
 	}
 	to.Flags().Int("version", 9999, "Version to migrate to")
 	to.MarkFlagRequired("version")
@@ -113,4 +119,11 @@ func buildMigrationCommand(datastoreName string) *cobra.Command {
 	r.AddCommand(force)
 	r.AddCommand(to)
 	return r
+}
+
+// bindMigrate is a PreRun rather than a PersistentPreRun on the migrate root
+// because cobra only runs the closest PersistentPreRun, which would shadow the
+// root command's global flag binding.
+func bindMigrate(_ *cobra.Command, _ []string) {
+	config.InitConfig()
 }

--- a/internal/cfgmodel/cfgmodel.go
+++ b/internal/cfgmodel/cfgmodel.go
@@ -7,40 +7,40 @@ import (
 
 // FriendlyStripeSync is the top-level config for the CLI tool.
 type FriendlyStripeSync struct {
-	Debug       bool `json:"debug"`
-	Purge       bool `json:"purge"`
-	Development bool `json:"development"`
+	Debug       bool `mapstructure:"debug" json:"debug"`
+	Purge       bool `mapstructure:"purge" json:"purge"`
+	Development bool `mapstructure:"development" json:"development"`
 
-	Stripe     Stripe     `json:"stripe"`
-	Postgres   Postgres   `json:"postgres"`
-	StripeSync StripeSync `json:"stripe_sync"`
+	Stripe     Stripe     `mapstructure:"stripe" json:"stripe"`
+	Postgres   Postgres   `mapstructure:"postgres" json:"postgres"`
+	StripeSync StripeSync `mapstructure:"stripe_sync" json:"stripe_sync"`
 
-	Logging Logging `json:"logging"`
+	Logging Logging `mapstructure:"logging" json:"logging"`
 }
 
 type Stripe struct {
-	APIKey string `json:"api_key"`
+	APIKey string `mapstructure:"api_key" json:"api_key"`
 }
 
 type Postgres struct {
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	User     string `json:"user"`
-	Password string `json:"password"`
-	DBName   string `json:"dbname"`
-	SSLMode  string `json:"sslmode"`
+	Host     string `mapstructure:"host" json:"host"`
+	Port     int    `mapstructure:"port" json:"port"`
+	User     string `mapstructure:"user" json:"user"`
+	Password string `mapstructure:"password" json:"password"`
+	DBName   string `mapstructure:"dbname" json:"dbname"`
+	SSLMode  string `mapstructure:"sslmode" json:"sslmode"`
 }
 
 type StripeSync struct {
-	IntervalSeconds int      `json:"interval_seconds"`
-	ExcludedFields  []string `json:"excluded_fields"`
+	IntervalSeconds int      `mapstructure:"interval_seconds" json:"interval_seconds"`
+	ExcludedFields  []string `mapstructure:"excluded_fields" json:"excluded_fields"`
 }
 
 type Logging struct {
-	Filename   string `json:"filename"`
-	MaxSize    int    `json:"max_size"`
-	MaxAge     int    `json:"max_age"`
-	MaxBackups int    `json:"max_backups"`
+	Filename   string `mapstructure:"filename" json:"filename"`
+	MaxSize    int    `mapstructure:"max_size" json:"max_size"`
+	MaxAge     int    `mapstructure:"max_age" json:"max_age"`
+	MaxBackups int    `mapstructure:"max_backups" json:"max_backups"`
 }
 
 // LibraryConfig returns the config as the stripesync library wants it.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,7 +28,7 @@ func writeConfig(t *testing.T, contents string) {
 	InitConfig()
 }
 
-// Keys containing an underscore only bind because we decode using the json tags,
+// Keys containing an underscore only bind because of the mapstructure tags,
 // mapstructure's field-name fallback does not match them.
 func TestGetStructUnderscoreKeysRoundTrip(t *testing.T) {
 	writeConfig(t, `
@@ -102,8 +102,8 @@ stripe_sync:
 }
 
 // The underscore-free spellings (stripe.apikey, stripesync.excludedfields, ...) are what
-// mapstructure's field-name fallback used to accept, and were the only keys that bound
-// before the json tags were honoured. They are deliberately no longer supported.
+// mapstructure's field-name fallback accepts, and were the only keys that bound before
+// the mapstructure tags were added. They are deliberately no longer supported.
 func TestGetStructLegacyKeysNoLongerBind(t *testing.T) {
 	writeConfig(t, `
 stripe:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeConfig writes contents to a temp yaml file and points the config loader at it.
+func writeConfig(t *testing.T, contents string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+
+	oldCfgFile := CfgFile
+	CfgFile = path
+	t.Cleanup(func() {
+		CfgFile = oldCfgFile
+		viper.Reset()
+	})
+
+	viper.Reset()
+	InitConfig()
+}
+
+// Keys containing an underscore only bind because we decode using the json tags,
+// mapstructure's field-name fallback does not match them.
+func TestGetStructUnderscoreKeysRoundTrip(t *testing.T) {
+	writeConfig(t, `
+stripe:
+  api_key: sk_test_fromfile
+stripe_sync:
+  interval_seconds: 900
+  excluded_fields:
+    - customer.tax_ids
+    - customer.phone
+logging:
+  filename: /var/log/fss.log
+  max_size: 11
+  max_age: 22
+  max_backups: 33
+postgres:
+  host: db.example.com
+  port: 6543
+  dbname: someotherdb
+  sslmode: require
+`)
+
+	cfg := GetStruct()
+
+	assert.Equal(t, "sk_test_fromfile", cfg.Stripe.APIKey)
+	assert.Equal(t, 900, cfg.StripeSync.IntervalSeconds)
+	assert.Equal(t, []string{"customer.tax_ids", "customer.phone"}, cfg.StripeSync.ExcludedFields)
+
+	assert.Equal(t, "/var/log/fss.log", cfg.Logging.Filename)
+	assert.Equal(t, 11, cfg.Logging.MaxSize)
+	assert.Equal(t, 22, cfg.Logging.MaxAge)
+	assert.Equal(t, 33, cfg.Logging.MaxBackups)
+
+	// Single-word keys worked before the fix, make sure they still do.
+	assert.Equal(t, "db.example.com", cfg.Postgres.Host)
+	assert.Equal(t, 6543, cfg.Postgres.Port)
+	assert.Equal(t, "someotherdb", cfg.Postgres.DBName)
+	assert.Equal(t, "require", cfg.Postgres.SSLMode)
+}
+
+func TestGetStructDefaults(t *testing.T) {
+	writeConfig(t, "debug: true\n")
+
+	cfg := GetStruct()
+
+	assert.True(t, cfg.Debug)
+	assert.Equal(t, "localhost", cfg.Postgres.Host)
+	assert.Equal(t, 5432, cfg.Postgres.Port)
+	assert.Equal(t, "friendlystripe", cfg.Postgres.DBName)
+	assert.Equal(t, "disable", cfg.Postgres.SSLMode)
+}
+
+// Env vars override the config file, including for underscore keys.
+func TestGetStructEnvOverride(t *testing.T) {
+	t.Setenv("FSS_STRIPE__API_KEY", "sk_test_fromenv")
+	t.Setenv("FSS_STRIPE_SYNC__INTERVAL_SECONDS", "42")
+	t.Setenv("FSS_POSTGRES__DBNAME", "envdb")
+
+	writeConfig(t, `
+stripe:
+  api_key: sk_test_fromfile
+stripe_sync:
+  interval_seconds: 900
+`)
+
+	cfg := GetStruct()
+
+	assert.Equal(t, "sk_test_fromenv", cfg.Stripe.APIKey)
+	assert.Equal(t, 42, cfg.StripeSync.IntervalSeconds)
+	assert.Equal(t, "envdb", cfg.Postgres.DBName)
+}
+
+// The underscore-free spellings (stripe.apikey, stripesync.excludedfields, ...) are what
+// mapstructure's field-name fallback used to accept, and were the only keys that bound
+// before the json tags were honoured. They are deliberately no longer supported.
+func TestGetStructLegacyKeysNoLongerBind(t *testing.T) {
+	writeConfig(t, `
+stripe:
+  apikey: sk_test_legacy
+stripesync:
+  intervalseconds: 77
+  excludedfields:
+    - customer.address
+logging:
+  maxsize: 5
+`)
+
+	cfg := GetStruct()
+
+	assert.Empty(t, cfg.Stripe.APIKey)
+	assert.Zero(t, cfg.StripeSync.IntervalSeconds)
+	assert.Empty(t, cfg.StripeSync.ExcludedFields)
+	assert.Zero(t, cfg.Logging.MaxSize)
+}


### PR DESCRIPTION
Two config fixes:

`migrate postgres <op>` never called `config.InitConfig()`, so viper was empty and every config field decoded to its zero value. 

The config models only had `json` struct tags but viper is using `mapstructure` struct tags.
